### PR TITLE
Added generation of linux auto runner of extracted test(s)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 nb-configuration.xml
 target
+.idea/
+jck-test-extractor.iml

--- a/src/main/java/jckextractor/TestExtractor.java
+++ b/src/main/java/jckextractor/TestExtractor.java
@@ -259,10 +259,15 @@ public class TestExtractor {
         }
         String tryRun = sb.toString()
                 .replace("{TEST}", options.testNameArg)
-                .replace("{DATE}", new Date().toString())
-                .replace("{JENKINS_URL}", envWithDefault("JENKINS_URL"))
-                .replace("{JOB_NAME}", envWithDefault("JOB_NAME"))
-                .replace("{BUILD_ID}", envWithDefault("BUILD_ID"));
+                .replace("{DATE}", new Date().toString());
+        if (System.getenv("JENKINS_URL") == null){
+            tryRun = tryRun.replaceAll(".*\\{JENKINS_URL\\}.*", "");
+        } else {
+            tryRun = tryRun
+                    .replace("{JENKINS_URL}", envWithDefault("JENKINS_URL"))
+                    .replace("{JOB_NAME}", envWithDefault("JOB_NAME"))
+                    .replace("{BUILD_ID}", envWithDefault("BUILD_ID"));
+        }
         String jto = System.getenv("JAVA_TOOL_OPTIONS");
         if (jto == null) {
             tryRun = tryRun.replace("={JAVA_TOOL_OPTIONS}", "=").replace("#{JAVA_TOOL_OPTIONS}", "# no JAVA_TOOL_OPTIONS found in runtime of this tool");

--- a/src/main/resources/jckextractor/res/tryRun.sh
+++ b/src/main/resources/jckextractor/res/tryRun.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+set -e
+if [ "x$TEST_JAVA" = "x" ] ; then
+  if [ "x$JAVA_HOME" = "x" ] ; then
+    export JAVA_HOME=$(dirname $(dirname $(readlink -f $(which javac))))
+  else
+    export JAVA_HOME="$JAVA_HOME"
+  fi
+else 
+  export JAVA_HOME="$TEST_JAVA"
+fi
+
+readonly JAVA="$JAVA_HOME/bin/java"
+readonly JAVAC="$JAVA_HOME/bin/javac"
+readonly JAVAP="$JAVA_HOME/bin/javap"
+
+echo "in-dir-script for"
+out=`pwd`/out
+mkdir -p out
+echo "*** {TEST} ***"
+echo "*** run at {DATE} ***"
+echo "*** Now using: $JAVA_HOME ***"
+echo "compiling . . . "
+javafiles=`find  -type f | grep "\\.java"`
+$JAVAC -d $out $javafiles
+echo "***********************************************************"
+echo "to set proper main method and -D switches and other params"
+echo "***********************************************************"
+echo " * visit: {JENKINS_URL}/job/{JOB_NAME}/{BUILD_ID}/artifacts/"
+echo " * visit: {JENKINS_URL}/job/{JOB_NAME}/{BUILD_ID}/java-reports/"
+echo " * search for {TEST} and expand"
+echo "Check the necessary -D and variables."
+echo "One of the most important -D is second and third machine the suite is using. Usually it is named as http-ftp-krb or agent"
+echo "the reproducer is far from being perfect, is even not minimalistic"
+echo "export JAVA_TOOL_OPTIONS={JAVA_TOOL_OPTIONS} if any"
+#{JAVA_TOOL_OPTIONS}
+echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+echo "$JAVA -cp $out your_-Ds your_main your_swithces"
+echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+echo "now wasting your time with attempt to run without them:"
+echo "looking for main class. This will take time!"
+classes=$(find $out -type  f | grep "\\.class$" | grep -v "\\$" | sort)
+classes_count=`echo "$classes" | wc -l`
+mainFiles=""
+mainClasses=""
+i=0;
+for class in $classes ; do
+  let i=i+1
+  if $JAVAP $class| grep -q "public static void main"   ; then
+    #echo "$i/$classes_count $class - main!"
+    echo -n "$i/$classes_count! "
+    mainFiles="$mainFiles "$class;
+    clazz=`$JAVAP  $class | head -n 2 | tail -n 1 | cut -d " " -f 3`
+    mainClasses="$mainClasses "$clazz;
+  else
+    #echo "$i/$classes_count $class - no main"
+    echo -n "$i/$classes_count "
+  fi
+done
+echo ""
+mainclasses_count=`echo "$mainClasses" | wc -w`
+echo "Executing $mainclasses_count found main methods"
+i=0;
+set +e
+for mainClass in $mainClasses ; do
+  let i=i+1
+  echo "$i/$mainclasses_count"
+  echo "$JAVA -cp $out $mainClass"
+  $JAVA -cp $out $mainClass
+  echo "***********************************************************"
+done


### PR DESCRIPTION
Hi! 
Added generation of linux auto runner of extracted test(s)

Please note thehunk of:

```
+            try (InputStream is = TestExtractor.class.getClassLoader().getResourceAsStream("jckextractor/res/TestMakefile.mk")) {
+               Files.copy(is, options.outputDir.resolve("Makefile"));
+            }
+       }

-        try (InputStream is = TestExtractor.class.getClassLoader().getResourceAsStream("jckextractor/res/TestMakefile.mk")) {
-            Files.copy(is, options.outputDir.resolve("Makefile"));
```

It is not visible in the diff, but moved creation of Makefile only ```  if (hasNatives) {``` is true
If hasNatives works, then it is better, if not, then I will move it back. I was not veryfing this hunk.

